### PR TITLE
Populate author metadata.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -119,11 +119,13 @@ analytics:
 
 
 # Site Author
+# Used as the defaults for defining what appears in the author sidebar.
+# https://mmistakes.github.io/minimal-mistakes/docs/configuration/#site-author
 author:
-  name             : "Your Name"
+  name             : "The Ion Fusion Team"
   avatar           : # path of avatar image, e.g. "/assets/images/bio-photo.jpg"
-  bio              : "I am an **amazing** person."
-  location         : "Somewhere"
+  bio              : #"I am an **amazing** person."
+  location         : #"Somewhere"
   email            :
   links:
     - label: "Email"
@@ -140,7 +142,7 @@ author:
       # url: "https://facebook.com/"
     - label: "GitHub"
       icon: "fab fa-fw fa-github"
-      # url: "https://github.com/"
+      url: "https://github.com/ion-fusion"
     - label: "Instagram"
       icon: "fab fa-fw fa-instagram"
       # url: "https://instagram.com/"

--- a/_data/authors.yml
+++ b/_data/authors.yml
@@ -1,0 +1,19 @@
+# This file defines the authors of content on the site, so their name and
+# contact info can decorate their posts.
+
+# https://mmistakes.github.io/minimal-mistakes/docs/authors/
+# https://mmistakes.github.io/minimal-mistakes/docs/configuration/#site-author
+
+Todd:
+    name             : "Todd Jonker"
+    avatar           : # path of avatar image, e.g. "/assets/images/bio-photo.jpg"
+    bio              : "I created Ion Fusion, and I think it's kind of cool."
+    location         : "Seattle, WA, USA"
+    email            :
+    links:
+        - label: "Email"
+          icon: "fas fa-fw fa-envelope-square"
+          # url: "mailto:your.name@email.com"                TODO
+        - label: "GitHub"
+          icon: "fab fa-fw fa-github"
+          url: "https://github.com/toddjonker"


### PR DESCRIPTION
A page's `author` frontmatter should contain a key from the `authors.yml`.

The info in `_config.yml` is used then the frontmatter has no `author`.