### PR TITLE
Add `_drafts` folder to make the capability clear.

### DIFF
--- a/_drafts/README.md
+++ b/_drafts/README.md
@@ -1,0 +1,9 @@
+
+https://jekyllrb.com/docs/posts/#drafts
+
+Drafts are posts without a date in the filename. They’re posts you’re still working on and don’t 
+want to publish yet.
+
+To preview your site with drafts, run `jekyll serve` or `jekyll build` with the `--drafts` switch. 
+Each will be assigned the value modification time of the draft file for its date, and thus you 
+will see currently edited drafts as the latest posts.


### PR DESCRIPTION
I just stumbled on it in the Jekyll docs, and wanted to make it self-documenting.