### PR TITLE
Add a simple `.envrc` to set up Ruby via `direnv`.

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,5 @@
+
+if [[ -x /opt/homebrew/opt/ruby/bin ]]
+then
+    PATH_add /opt/homebrew/opt/ruby/bin
+fi


### PR DESCRIPTION
On Mac, the system Ruby is too old for this project. This automates and localizes the correct environment.

Personally, I don't like to add these things to my default PATH, since that can lead to conflicts across projects.