### PR TITLE
Add Dockerfile for jekyll build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+/.git
+/Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,96 @@
+# syntax=docker/dockerfile:1.4
+
+# See the README.md for some example docker invocations with this Dockerfile.
+
+# Debian official container images; https://hub.docker.com/_/debian
+FROM debian:bookworm-slim@sha256:90522eeb7e5923ee2b871c639059537b30521272f10ca86fdbbbb2b75a8c40cd
+
+# Use Debian snapshot repositories; see https://snapshot.debian.org/
+ARG DEBIAN_SNAPSHOT="20250531T000000Z"
+COPY <<EOF /etc/apt/sources.list.d/debian.sources
+Types: deb
+URIs: http://snapshot.debian.org/archive/debian/${DEBIAN_SNAPSHOT}
+Suites: bookworm bookworm-updates
+Components: main
+Signed-By: /usr/share/keyrings/debian-archive-keyring.gpg
+Check-Valid-Until: no
+
+Types: deb
+URIs: http://snapshot.debian.org/archive/debian-security/${DEBIAN_SNAPSHOT}
+Suites: bookworm-security
+Components: main
+Signed-By: /usr/share/keyrings/debian-archive-keyring.gpg
+Check-Valid-Until: no
+EOF
+
+# Install Debian packages:
+RUN --network=default <<EOF
+set -eux
+export DEBIAN_FRONTEND=noninteractive
+apt-get update
+apt-get --assume-yes  install ruby bundler
+apt-get clean
+EOF
+
+# Create the build user and home directory:
+RUN --network=none <<EOF
+set -eux
+useradd --create-home --shell /bin/sh build
+chown build:build /home/build
+EOF
+
+# Switch to the build user, and into their home directory for clear ownership:
+USER build
+WORKDIR /home/build/fusion-site
+
+# Establish a build script for following steps; this may seem odd, but it
+# allows the bundle/jekyll invocations to work whether running with the
+# copied-in files, or files via a volume mount over the workdir. Otherwise,
+# such a volume mount would also over-mount the installed gems and thus fail.
+COPY --chmod=755 <<'EOF' /bin/bundlew
+#!/bin/sh
+set -eu
+bundle config set --local gemfile '../Gemfile'
+bundle config set --local path 'bundle'
+case "$1" in
+    exec-jekyll-build)
+        shift
+        set -x
+        exec bundle exec jekyll build \
+                --destination ../site \
+                --strict_front_matter \
+                --incremental \
+                "$@"
+        ;;
+    exec-jekyll-serve)
+        shift
+        set -x
+        exec bundle exec jekyll serve \
+                --destination ../site \
+                --incremental \
+                --host 0.0.0.0 \
+                "$@"
+        ;;
+    *)
+        set -x
+        exec bundle "$@"
+        ;;
+esac
+EOF
+
+# Install Ruby packages:
+COPY --chown=build:build Gemfile ../Gemfile
+RUN --network=default bundlew install
+
+# Fix Scss file encoding errors; https://github.com/jekyll/jekyll/issues/4268
+ENV LC_ALL="C.UTF-8" LANG="en_US.UTF-8" LANGUAGE="en_US.UTF-8"
+
+# Copy in all site sources; following commands will be rerun for every change:
+COPY --chown=build:build . .
+
+# Run the jekyll build to ensure it works as a precondition for image build;
+# sadly, this "requires" network access to work, at least as of Bundler 2.3.15:
+RUN --network=default bundlew exec-jekyll-build
+
+# Default command is to run the jekyll development server:
+CMD ["bundlew", "exec-jekyll-serve", "--livereload"]

--- a/README.md
+++ b/README.md
@@ -1,9 +1,58 @@
 # ion-fusion.github.io
-Source of org-level GitHub Pages
 
-## Local Development
+Source for the Fusion website at: <https://ion-fusion.dev/>
 
-On Mac, you'll need to install Ruby via Homebrew:
+The site is currently built with Jekyll, and deployed via GitHub Pages.
+
+## Development
+
+### Docker
+
+If you have a Docker-compatible CLI ([docker], [podman], [nerdctl], ...) capable of running Debian
+Linux containers, you can build and serve the site via the included [Dockerfile](Dockerfile) with
+invocations like:
+
+```shell
+docker build -t fusion-site .
+```
+
+Or, without even acquiring the sources:
+
+```shell
+docker build -t fusion-site https://github.com/ion-fusion/ion-fusion.github.io.git
+```
+
+After building, you can run the jekyll server with invocations like:
+
+```shell
+docker run -p 4000:4000 fusion-site
+```
+
+Or, to leverage Jekyll's auto-generation and live-reloading:
+
+```shell
+docker run -p 4000:4000 -p 35729:35729 -v "$(pwd):/home/build/fusion-site" fusion-site
+```
+
+You can pass extra flags to `jeykll serve` with invocations like:
+
+```shell
+docker run -p 4000:4000 fusion-site bundlew exec-jekyll-serve --drafts
+```
+
+Or, even run arbitrary `jekyll` commands with:
+
+```shell
+docker run fusion-site bundlew exec jekyll --help
+```
+
+[docker]: https://www.docker.com/products/cli/
+[podman]: https://podman.io/
+[nerdctl]: https://github.com/containerd/nerdctl
+
+### macOS
+
+On Mac, you'll probably install Ruby via Homebrew:
 
 ```shell
 brew install ruby
@@ -17,15 +66,13 @@ PATH=/opt/homebrew/opt/ruby/bin:$PATH
 
 (I like to use `direnv` for the latter, so it's a local configuration.)
 
-
-### After checkout
+After checkout:
 
 ```shell
 bundle install
 ```
 
-
-### Serve the Site Locally
+To serve the site locally:
 
 ```shell
 bundle exec jekyll serve


### PR DESCRIPTION
This commit adds a Dockerfile for running the jekyll build and development server, which should help streamline developer onboarding. Docker (or Podman, Nerdctl, Finch, ...) is often one of the few tools found reliably within many systems "trusted computing bases", whereas `ruby` and `bundle` are not-so-often available - particularly at compatible versions. Fedora's atomic distributions (Silverblue et al) are such examples.

This Dockerfile is, for now, a one-stage build atop Debian 12 Bookworm (`bookworm-slim`) as the base image. We lock the parent digest and use Debian snapshots to improve reproducibility of the image builds.

The Dockerfile performs fairly efficient build layering; for example, the Debian packages install is independent of sources (other than the `Dockerfile` itself, of course), and the Ruby gems install will only run when the `Gemfile` changes.

The Dockerfile is more intricate than usual, so as to support bi-modal `jekyll serve` functionality - either when running off static container sources for conventional `docker run` invocations, or for when over-mounting the workdir with local sources to leverage Jekyll's auto-reload functionality.

This commit updates the README with `docker` commands for building and running the container.