### PR TITLE
Fix Jekyll warnings

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,3 +33,6 @@ gem "wdm", "~> 0.1", :platforms => [:mingw, :x64_mingw, :mswin]
 # Lock `http_parser.rb` gem to `v0.6.x` on JRuby builds since newer versions of the gem
 # do not have a Java counterpart.
 gem "http_parser.rb", "~> 0.6.0", :platforms => [:jruby]
+
+# Fix retry middleware warnings on jekyll build:
+gem 'faraday-retry'

--- a/_config.yml
+++ b/_config.yml
@@ -246,8 +246,8 @@ timezone: # https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
 
 
 # Pagination with jekyll-paginate
-paginate: 5 # amount of posts to show
-paginate_path: /page:num/
+# paginate: 5 # amount of posts to show
+# paginate_path: /page:num/
 
 # Pagination with jekyll-paginate-v2
 # See https://github.com/sverrirs/jekyll-paginate-v2/blob/master/README-GENERATOR.md#site-configuration


### PR DESCRIPTION
Two small changes to fix warnings and issues emitted by Jekyll on `build` and `serve`:

### Add faraday-retry gem to fix build warnings

Based on the message previously emitted by `jekyll serve`, and the
faraday-retry gem's page [0], I understand this is used to improve
resiliency in the face of client errors. Big deal for `jekyll serve`,
but fewer build warnings is nice.

[0]: https://rubygems.org/gems/faraday-retry

### Disable pagination to fix jekyll warnings

`jekyll build` and `jekyll serve` were emitting yellow warnings about
pagination not working without an index.html. We don't need or use
pagination yet, so just disable it to fix those warnings.

-------

## Testing

Built and ran `jekyll` commands (albeit via `docker`, on top of [mcinglis/add-dockerfile](https://github.com/ion-fusion/ion-fusion.github.io/pull/22)) - and no more warnings.